### PR TITLE
Fix/bug1 unwanted quotes

### DIFF
--- a/Tests/TfsCommands.New-TfsWorkspace.Tests.ps1
+++ b/Tests/TfsCommands.New-TfsWorkspace.Tests.ps1
@@ -59,6 +59,19 @@ Describe 'New-TfsWorkspace' {
     Assert-MockCalled @assertArgs
   }
 
+  It 'handles comments containing double quotes' {
+    New-TfsWorkspace 'some-workspace' -Comment 'a "comment"'
+
+    $assertArgs = @{
+      ModuleName = 'TfsCommands'
+      CommandName = 'Invoke-TfsCommandAtLocation'
+      ParameterFilter = {
+        $Arguments -icontains "`"/comment:a `"`"comment`"`"`""
+      }
+    }
+    Assert-MockCalled @assertArgs
+  }
+
   It 'creates new workspace with root work folder mapping to specified path' {
     $workspaceName = 'some-workspace'
     $collectionUrl = 'http://some/tfs/collection'

--- a/Tests/TfsCommands.New-TfsWorkspace.Tests.ps1
+++ b/Tests/TfsCommands.New-TfsWorkspace.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'New-TfsWorkspace' {
         $Arguments -icontains '/new' -and
         $Arguments -icontains $workspaceName -and
         $Arguments -icontains "/collection:$collectionUrl" -and
-        $Arguments -icontains "/comment:'$comment'" -and
+        $Arguments -icontains "`"/comment:$comment`"" -and
         $Arguments -icontains "/noprompt" -and
         $Arguments -icontains "/permission:private" -and
         $Arguments -icontains "/location:server" -and

--- a/TfsCommands.psm1
+++ b/TfsCommands.psm1
@@ -68,13 +68,13 @@ param (
       $rootMapPath
       'workspace'
       '/new'
+      $Name
       (NoPromptParameter)
       (CollectionParameter $CollectionUrl)
       (CommentParameter $Comment)
       (LocationParameter)
       (PermissionParameter)
-      (ComputerParameter)
-      $Name)
+      (ComputerParameter))
     Invoke-TfsCommandAtLocation @cmdArgs
     if ($NoMap) {
       # Previous command forced setting a mapping to root $/ which is not
@@ -241,9 +241,9 @@ param (
   [String] $Comment
 )
   $Comment = ($Comment | Coalesce '')
-  $cmdArgs = @('comment')
-  if ($Comment -ne '') { $cmdArgs += ('''' + $Comment + '''') }
-  OptionalNamedParameter @cmdArgs
+  $parameter = OptionalNamedParameter 'comment' $Comment
+  # wrap whole parameter in quotes to prevent later being split on whitespace
+  if ($parameter) { "`"$parameter`"" } else { $null }
 }
 
 function VersionParameter {
@@ -337,7 +337,7 @@ param (
   [String] $Name,
   [String] $Value
 )
-  $Value = ($Value | Coalesce '')
+  $Value = ($Value | DefaultIfBlank '')
   if ($Value -ne '') { Parameter $Name $Value } else { $null }
 }
 

--- a/TfsCommands.psm1
+++ b/TfsCommands.psm1
@@ -241,6 +241,7 @@ param (
   [String] $Comment
 )
   $Comment = ($Comment | Coalesce '')
+  $Comment = EscapeDoubleQuotes $Comment
   $parameter = OptionalNamedParameter 'comment' $Comment
   # wrap whole parameter in quotes to prevent later being split on whitespace
   if ($parameter) { "`"$parameter`"" } else { $null }
@@ -370,6 +371,14 @@ param (
     $parameter = $Value
   }
   $parameter
+}
+
+function EscapeDoubleQuotes {
+param (
+  [String] $value
+)
+  # Simply replace with 'dos' two quotes escape sequence
+  $value -replace '"', '""'
 }
 
 function CommandArguments {


### PR DESCRIPTION
Fixes #1. Single quotes replaced with double quotes around whole parameter not just the comment body part.  Any double quotes in the comment body are escaped.
