### PR TITLE
Default local path to current directory

### DIFF
--- a/Tests/TfsCommands.New-TfsWorkspace.Tests.ps1
+++ b/Tests/TfsCommands.New-TfsWorkspace.Tests.ps1
@@ -145,13 +145,13 @@ Describe 'New-TfsWorkspace' {
     Assert-MockCalled @assertArgs
   }
   
-  It 'uses temporary location if local path for root mapping not given' {
+  It 'uses current directory if local path for root mapping not given' {
     New-TfsWorkspace 'some-workspace'
 
     $assertArgs = @{
       ModuleName = 'TfsCommands'
       CommandName = 'Invoke-TfsCommandAtLocation'
-      ParameterFilter = { $Location -eq 'TestDrive:\tempdir' }
+      ParameterFilter = { $Location -eq '.' }
     }
     Assert-MockCalled @assertArgs
   }

--- a/TfsCommands.psm1
+++ b/TfsCommands.psm1
@@ -53,8 +53,7 @@ param (
   [String] $Path,
   [switch] $NoMap
 )
-  $Path = ($Path | DefaultIfBlank '')
-  if ($Path -eq '') { $NoMap = $true }
+  $Path = ($Path | DefaultIfBlank '.')
   $tmpDir = $null
   try {
     $rootMapPath = $Path


### PR DESCRIPTION
Fixes #3 
New-TfsWorkspace defaults to current directory for local path mapped to
root $/ if path not given and -NoMap switch not set.
